### PR TITLE
fix some issues with hashtags on bluesky

### DIFF
--- a/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/utils/HashtagTextUtils.kt
+++ b/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/utils/HashtagTextUtils.kt
@@ -23,7 +23,7 @@ object HashtagTextUtils {
                 char == '#' -> {
                     if (start.isStartMark) {
                         start = index
-                    } else if (!end.isEndMark) {
+                    } else {
                         // abc#cde#
                         end = index
                     }
@@ -36,8 +36,9 @@ object HashtagTextUtils {
                 }
             }
             if (!start.isStartMark && !end.isEndMark) {
-                list += TextRange(start = start, end = end + 1)
-                start = MARK_START
+                list += TextRange(start = start, end = end)
+                // parse #abc#def as #abc and #def
+                start = if (char == '#') index else MARK_START
                 end = MARK_END
             }
             index++

--- a/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/internal/usecase/PublishingPostUseCase.kt
+++ b/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/internal/usecase/PublishingPostUseCase.kt
@@ -300,7 +300,9 @@ class PublishingPostUseCase @Inject constructor(
         val facetList = mutableListOf<Facet>()
         val hashtags = HashtagTextUtils.findHashtags(content)
         for (hashtag in hashtags) {
-            val tag = content.substring(hashtag.start, hashtag.end)
+            // bsky doesn't handle empty hashtags elegantly
+            if (hashtag.start + 1 >= hashtag.end) continue
+            val tag = content.substring(hashtag.start + 1, hashtag.end)
             val facet = Facet(
                 index = convertIndex(hashtag, content),
                 features = listOf(


### PR DESCRIPTION
See #79. This is not a perfect solution, but it makes hashtags usable on Bluesky. As far as I'm aware, no functionality with Mastodon is changed - the only differences would be visual, but I don't think they'd actually show up. For Bluesky, it is a large improvement.

One thing this PR does not address is something I mentioned in #79 -- bsky parses `#abc!` as the tag `#abc` followed by `!`. However, I'm not sure of the best way to address this, as there are differences between how Mastodon and Bluesky parse tags (see [here](https://github.com/mastodon/mastodon/blob/main/app/javascript/mastodon/utils/hashtags.ts) for mastodon tags), likely requiring conditional processing, and I'm not confident of how to proceed. I'm fine with that being handled later though.

With this change, the text `this is a #testpost! foo #hashtag #fread #abc#def ##foo #` will be submitted to bsky as
> this is a [#testpost!](https://bsky.app/hashtag/testpost!) foo [#hashtag](https://bsky.app/hashtag/hashtag) [#fread](https://bsky.app/hashtag/fread) [#abc](https://bsky.app/hashtag/abc)[#def](https://bsky.app/hashtag/def) #[#foo](https://bsky.app/hashtag/foo) #

As stated before, this is not quite every issue I brought up, but it fixes enough to make it usable. Empty hashtags (hashtag facets of length 1 or less) are not submitted to Bluesky because they seem to not work nicely, and I can't imagine anyone using them. However, they are rendered in the Fread app (with this PR) when drafting a post.