### PR TITLE
Show user profile directly if there is only one profile added

### DIFF
--- a/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/screen/StatusScreenProvider.kt
+++ b/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/screen/StatusScreenProvider.kt
@@ -1,5 +1,6 @@
 package com.zhangke.fread.status.screen
 
+import androidx.compose.runtime.Composable
 import androidx.navigation3.runtime.NavKey
 import com.zhangke.framework.nav.Tab
 import com.zhangke.framework.network.FormalBaseUrl
@@ -76,6 +77,10 @@ class StatusScreenProvider(
         return providerList.firstNotNullOfOrNull {
             it.getUserDetailScreenWithoutAccount(uri)
         }
+    }
+
+    fun getUserDetailContent(account: LoggedAccount): (@Composable () -> Unit)? {
+        return providerList.firstNotNullOfOrNull { it.getUserDetailContent(account) }
     }
 
     fun getTagTimelineScreen(
@@ -159,6 +164,10 @@ interface IStatusScreenProvider {
     fun getUserDetailScreen(locator: PlatformLocator, uri: FormalUri, userId: String?): NavKey?
 
     fun getUserDetailScreenWithoutAccount(uri: FormalUri): NavKey? {
+        return null
+    }
+
+    fun getUserDetailContent(account: LoggedAccount): (@Composable () -> Unit)? {
         return null
     }
 

--- a/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/config/FreadConfigManager.kt
+++ b/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/config/FreadConfigManager.kt
@@ -29,6 +29,7 @@ class FreadConfigManager(
         private const val LOCAL_KEY_THEME_TYPE = "theme_type"
         private const val LOCAL_KEY_OPEN_URL_IN_APP_BROWSER = "open_url_in_app_browser"
         private const val LOCAL_KEY_ENABLE_BLUR_APP_BAR_STYLE = "enable_blur_app_bar_style"
+        private const val LOCAL_KEY_JUMP_TO_PROFILE = "jump_to_profile"
     }
 
     private val _statusConfigFlow = MutableStateFlow(StatusConfig.default())
@@ -49,6 +50,8 @@ class FreadConfigManager(
         private set
     var openUrlInAppBrowser: Boolean = true
         private set
+    var jumpToProfile: Boolean = false
+        private set
 
     suspend fun initConfig() {
         _statusConfigFlow.value = readLocalStatusConfig()
@@ -57,6 +60,8 @@ class FreadConfigManager(
             localConfigManager.getBoolean(LOCAL_KEY_AUTO_PLAY_INLINE_VIDEO) ?: false
         openUrlInAppBrowser =
             localConfigManager.getBoolean(LOCAL_KEY_OPEN_URL_IN_APP_BROWSER) != false
+        jumpToProfile =
+            localConfigManager.getBoolean(LOCAL_KEY_JUMP_TO_PROFILE) ?: false
         _enableBlurAppBarStyleFlow.value =
             localConfigManager.getBoolean(LOCAL_KEY_ENABLE_BLUR_APP_BAR_STYLE) != false
         _homeTabNextButtonVisibleFlow.value =
@@ -94,6 +99,13 @@ class FreadConfigManager(
         openUrlInAppBrowser = value
         withContext(Dispatchers.IO) {
             localConfigManager.putBoolean(LOCAL_KEY_OPEN_URL_IN_APP_BROWSER, value)
+        }
+    }
+
+    suspend fun updateJumpToProfile(value: Boolean) {
+        jumpToProfile = value
+        withContext(Dispatchers.IO) {
+            localConfigManager.putBoolean(LOCAL_KEY_JUMP_TO_PROFILE, value)
         }
     }
 

--- a/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/common/DetailPageScaffold.kt
+++ b/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/common/DetailPageScaffold.kt
@@ -44,6 +44,7 @@ fun DetailPageScaffold(
     followInfoLine: @Composable () -> Unit,
     topDetailContentAction: (@Composable () -> Unit)? = null,
     bottomArea: (@Composable () -> Unit)? = null,
+    showBackButton: Boolean = true,
     content: @Composable (progress: Float) -> Unit,
 ) {
     DetailPageScaffold(
@@ -52,6 +53,7 @@ fun DetailPageScaffold(
         title = title,
         contentCanScrollBackward = contentCanScrollBackward,
         onBackClick = onBackClick,
+        showBackButton = showBackButton,
         topBarActions = topBarActions,
         topDetailContent = { progress ->
             DetailHeaderContent(
@@ -85,6 +87,7 @@ fun DetailPageScaffold(
     onBackClick: () -> Unit,
     topBarActions: @Composable RowScope.() -> Unit,
     topDetailContent: @Composable BoxScope.(Float) -> Unit,
+    showBackButton: Boolean = true,
     content: @Composable (progress: Float) -> Unit,
 ) {
     Scaffold(
@@ -112,6 +115,7 @@ fun DetailPageScaffold(
                         title = title,
                         onBackClick = onBackClick,
                         actions = topBarActions,
+                        showBackButton = showBackButton,
                     )
                 },
                 headerContent = { progress ->

--- a/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/common/DetailTopBar.kt
+++ b/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/common/DetailTopBar.kt
@@ -27,6 +27,7 @@ fun DetailTopBar(
     title: RichText,
     onBackClick: () -> Unit,
     actions: @Composable RowScope.() -> Unit,
+    showBackButton: Boolean = true,
 ) {
     val progressTopBarContainerColor = MaterialTheme.colorScheme.surface.copy(progress)
     val blurEnabled = progress >= 1F
@@ -58,7 +59,9 @@ fun DetailTopBar(
             }
         },
         navigationIcon = {
-            Toolbar.BackButton(onBackClick = onBackClick)
+            if (showBackButton) {
+                Toolbar.BackButton(onBackClick = onBackClick)
+            }
         },
         windowInsets = WindowInsets.statusBars,
         colors = TopAppBarColors.default(

--- a/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/home/ProfileScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/home/ProfileScreen.kt
@@ -36,12 +36,15 @@ import com.zhangke.framework.composable.plus
 import com.zhangke.framework.nav.LocalNavBackStack
 import com.zhangke.fread.common.composable.EmptyContent
 import com.zhangke.fread.common.composable.EmptyContentType
+import com.zhangke.fread.common.config.LocalFreadConfigManager
 import com.zhangke.fread.commonbiz.shared.LocalModuleScreenVisitor
 import com.zhangke.fread.commonbiz.shared.composable.UserInfoCard
 import com.zhangke.fread.localization.LocalizedString
 import com.zhangke.fread.profile.screen.setting.SettingScreenNavKey
+import com.zhangke.fread.status.StatusProvider
 import com.zhangke.fread.status.account.LoggedAccount
 import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
@@ -50,22 +53,35 @@ fun ProfileScreen() {
     val viewModel = koinViewModel<ProfileHomeViewModel>()
     val uiState by viewModel.uiState.collectAsState()
     val moduleScreenVisitor = LocalModuleScreenVisitor.current
+    val freadConfigManager = LocalFreadConfigManager.current
+    val statusProvider: StatusProvider = koinInject()
     LaunchedEffect(Unit) {
         viewModel.refreshAccountInfo()
     }
-    ProfileHomePageContent(
-        uiState = uiState,
-        onAddAccountClick = {
-            backStack.add(moduleScreenVisitor.feedsScreenVisitor.getAddContentScreen())
-        },
-        onSettingClick = {
-            backStack.add(SettingScreenNavKey)
-        },
-        onAccountClick = {
-            viewModel.onAccountClick(it)
-        },
-        onLoginClick = viewModel::onLoginClick,
-    )
+    val singleAccount = uiState.accountDataList.singleOrNull()?.account?.account
+    val jumpContent: (@Composable () -> Unit)? =
+        if (freadConfigManager.jumpToProfile && singleAccount != null) {
+            statusProvider.screenProvider.getUserDetailContent(singleAccount)
+        } else {
+            null
+        }
+    if (jumpContent != null) {
+        jumpContent()
+    } else {
+        ProfileHomePageContent(
+            uiState = uiState,
+            onAddAccountClick = {
+                backStack.add(moduleScreenVisitor.feedsScreenVisitor.getAddContentScreen())
+            },
+            onSettingClick = {
+                backStack.add(SettingScreenNavKey)
+            },
+            onAccountClick = {
+                viewModel.onAccountClick(it)
+            },
+            onLoginClick = viewModel::onLoginClick,
+        )
+    }
     ConsumeFlow(viewModel.openPageFlow) {
         backStack.add(it)
     }

--- a/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.OpenInBrowser
 import androidx.compose.material.icons.filled.PlayCircleOutline
 import androidx.compose.material.icons.filled.ViewTimeline
@@ -40,6 +41,7 @@ fun BehaviorSettingsScreen(viewModel: BehaviorSettingsViewModel) {
         onAlwaysShowSensitive = viewModel::onAlwaysShowSensitiveContentChanged,
         onTimelineDefaultPositionChanged = viewModel::onTimelineDefaultPositionChanged,
         onOpenUrlInAppBrowserChanged = viewModel::onOpenUrlInAppBrowserChanged,
+        onJumpToProfileChanged = viewModel::onJumpToProfileChanged,
     )
 }
 
@@ -51,6 +53,7 @@ private fun BehaviorSettingsContent(
     onAlwaysShowSensitive: (Boolean) -> Unit,
     onTimelineDefaultPositionChanged: (TimelineDefaultPosition) -> Unit,
     onOpenUrlInAppBrowserChanged: (Boolean) -> Unit,
+    onJumpToProfileChanged: (Boolean) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -81,8 +84,26 @@ private fun BehaviorSettingsContent(
                 position = uiState.timelineDefaultPosition,
                 onPositionChanged = onTimelineDefaultPositionChanged,
             )
+            JumpToProfileItem(
+                jumpToProfile = uiState.jumpToProfile,
+                onJumpToProfileChanged = onJumpToProfileChanged,
+            )
         }
     }
+}
+
+@Composable
+private fun JumpToProfileItem(
+    jumpToProfile: Boolean,
+    onJumpToProfileChanged: (on: Boolean) -> Unit,
+) {
+    SettingItemWithSwitch(
+        icon = Icons.Default.AccountCircle,
+        title = stringResource(LocalizedString.setting_item_jump_to_profile_title),
+        subtitle = stringResource(LocalizedString.setting_item_jump_to_profile_subtitle),
+        checked = jumpToProfile,
+        onCheckedChangeRequest = onJumpToProfileChanged,
+    )
 }
 
 @Composable

--- a/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsUiState.kt
+++ b/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsUiState.kt
@@ -7,4 +7,5 @@ data class BehaviorSettingsUiState(
     val alwaysShowSensitiveContent: Boolean,
     val timelineDefaultPosition: TimelineDefaultPosition,
     val openUrlInAppBrowser: Boolean,
+    val jumpToProfile: Boolean,
 )

--- a/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsViewModel.kt
@@ -19,6 +19,7 @@ class BehaviorSettingsViewModel(
             alwaysShowSensitiveContent = false,
             timelineDefaultPosition = TimelineDefaultPosition.NEWEST,
             openUrlInAppBrowser = freadConfigManager.openUrlInAppBrowser,
+            jumpToProfile = freadConfigManager.jumpToProfile,
         )
     )
     val uiState = _uiState.asStateFlow()
@@ -63,6 +64,13 @@ class BehaviorSettingsViewModel(
         viewModelScope.launch {
             freadConfigManager.updateOpenUrlInAppBrowser(openInApp)
             _uiState.update { it.copy(openUrlInAppBrowser = openInApp) }
+        }
+    }
+
+    fun onJumpToProfileChanged(on: Boolean) {
+        viewModelScope.launch {
+            freadConfigManager.updateJumpToProfile(on)
+            _uiState.update { it.copy(jumpToProfile = on) }
         }
     }
 }

--- a/localization/src/commonMain/composeResources/values/strings.xml
+++ b/localization/src/commonMain/composeResources/values/strings.xml
@@ -253,4 +253,6 @@
     <string name="setting_item_open_url_by_system_subtitle">When enabled, Fread will open links with the system browser.</string>
     <string name="setting_item_solid_bar_background_title">Solid bar background</string>
     <string name="setting_item_solid_bar_background_subtitle">Make the top and bottom bars solid instead of blurred.</string>
+    <string name="setting_item_jump_to_profile_title">Jump to profile</string>
+    <string name="setting_item_jump_to_profile_subtitle">Jump directly to your profile if there is only one added</string>
 </resources>

--- a/localization/src/commonMain/kotlin/com/zhangke/fread/localization/LocalizedString.kt
+++ b/localization/src/commonMain/kotlin/com/zhangke/fread/localization/LocalizedString.kt
@@ -658,4 +658,8 @@ object LocalizedString {
         localizedString.setting_item_solid_bar_background_title
     val setting_item_solid_bar_background_subtitle =
         localizedString.setting_item_solid_bar_background_subtitle
+    val setting_item_jump_to_profile_title =
+        localizedString.setting_item_jump_to_profile_title
+    val setting_item_jump_to_profile_subtitle =
+        localizedString.setting_item_jump_to_profile_subtitle
 }

--- a/plugins/activitypub-app/src/commonMain/kotlin/com/zhangke/fread/activitypub/app/ActivityPubScreenProvider.kt
+++ b/plugins/activitypub-app/src/commonMain/kotlin/com/zhangke/fread/activitypub/app/ActivityPubScreenProvider.kt
@@ -1,5 +1,6 @@
 package com.zhangke.fread.activitypub.app
 
+import androidx.compose.runtime.Composable
 import androidx.navigation3.runtime.NavKey
 import com.zhangke.framework.nav.Tab
 import com.zhangke.framework.network.FormalBaseUrl
@@ -15,6 +16,7 @@ import com.zhangke.fread.activitypub.app.internal.screen.hashtag.HashtagTimeline
 import com.zhangke.fread.activitypub.app.internal.screen.instance.InstanceDetailScreenKey
 import com.zhangke.fread.activitypub.app.internal.screen.status.post.PostStatusScreenKey
 import com.zhangke.fread.activitypub.app.internal.screen.status.post.PostStatusScreenRoute
+import com.zhangke.fread.activitypub.app.internal.screen.user.UserDetailScreen
 import com.zhangke.fread.activitypub.app.internal.screen.user.UserDetailScreenKey
 import com.zhangke.fread.activitypub.app.internal.screen.user.list.UserListScreenKey
 import com.zhangke.fread.activitypub.app.internal.screen.user.list.UserListType
@@ -28,6 +30,7 @@ import com.zhangke.fread.status.model.notActivityPub
 import com.zhangke.fread.status.platform.BlogPlatform
 import com.zhangke.fread.status.screen.IStatusScreenProvider
 import com.zhangke.fread.status.uri.FormalUri
+import org.koin.compose.viewmodel.koinViewModel
 
 class ActivityPubScreenProvider(
     private val userUriTransformer: UserUriTransformer,
@@ -180,5 +183,19 @@ class ActivityPubScreenProvider(
     override fun getPublishScreen(account: LoggedAccount, text: String): NavKey? {
         if (account !is ActivityPubLoggedAccount) return null
         return PostStatusScreenKey(accountUri = account.uri, defaultContent = text)
+    }
+
+    override fun getUserDetailContent(account: LoggedAccount): (@Composable () -> Unit)? {
+        if (account !is ActivityPubLoggedAccount) return null
+        val locator = account.locator
+        val userUri = account.uri
+        return {
+            UserDetailScreen(
+                viewModel = koinViewModel(),
+                locator = locator,
+                userUri = userUri,
+                showBackButton = false,
+            )
+        }
     }
 }

--- a/plugins/activitypub-app/src/commonMain/kotlin/com/zhangke/fread/activitypub/app/internal/screen/user/UserDetailScreen.kt
+++ b/plugins/activitypub-app/src/commonMain/kotlin/com/zhangke/fread/activitypub/app/internal/screen/user/UserDetailScreen.kt
@@ -130,6 +130,7 @@ fun UserDetailScreen(
     userUri: FormalUri? = null,
     webFinger: WebFinger? = null,
     userId: String? = null,
+    showBackButton: Boolean = true,
 ) {
     val backstack = LocalNavBackStack.currentOrThrow
     val browserLauncher = LocalActivityBrowserLauncher.current
@@ -141,6 +142,7 @@ fun UserDetailScreen(
         uiState = uiState,
         messageFlow = viewModel.messageFlow,
         userId = userId,
+        showBackButton = showBackButton,
         onFavouritesClick = {
             backstack.add(
                 StatusListScreenKey(
@@ -293,8 +295,10 @@ fun UserDetailScreen(
             viewModel.onLogoutClick()
         },
     )
-    ConsumeFlow(viewModel.finishPageFlow) {
-        backstack.removeLastOrNull()
+    if (showBackButton) {
+        ConsumeFlow(viewModel.finishPageFlow) {
+            backstack.removeLastOrNull()
+        }
     }
 }
 
@@ -303,6 +307,7 @@ private fun UserDetailContent(
     uiState: UserDetailUiState,
     messageFlow: SharedFlow<TextString>,
     userId: String?,
+    showBackButton: Boolean,
     onBackClick: () -> Unit,
     onSearchClick: () -> Unit,
     onFavouritesClick: () -> Unit,
@@ -357,6 +362,7 @@ private fun UserDetailContent(
         },
         onMaybeHashtagClick = onMaybeHashtagClick,
         onBackClick = onBackClick,
+        showBackButton = showBackButton,
         topBarActions = {
             ToolbarActions(
                 uiState = uiState,

--- a/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyScreenProvider.kt
+++ b/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyScreenProvider.kt
@@ -1,5 +1,6 @@
 package com.zhangke.fread.bluesky
 
+import androidx.compose.runtime.Composable
 import androidx.navigation3.runtime.NavKey
 import com.zhangke.framework.architect.json.globalJson
 import com.zhangke.framework.nav.Tab
@@ -13,6 +14,7 @@ import com.zhangke.fread.bluesky.internal.screen.feeds.following.BskyFollowingFe
 import com.zhangke.fread.bluesky.internal.screen.feeds.home.HomeFeedsScreenNavKey
 import com.zhangke.fread.bluesky.internal.screen.content.BlueskyContentTab
 import com.zhangke.fread.bluesky.internal.screen.publish.PublishPostScreenNavKey
+import com.zhangke.fread.bluesky.internal.screen.user.detail.BskyUserDetailScreen
 import com.zhangke.fread.bluesky.internal.screen.user.detail.BskyUserDetailScreenNavKey
 import com.zhangke.fread.bluesky.internal.screen.user.list.UserListScreenNavKey
 import com.zhangke.fread.bluesky.internal.screen.user.list.UserListType
@@ -26,6 +28,8 @@ import com.zhangke.fread.status.model.notBluesky
 import com.zhangke.fread.status.platform.BlogPlatform
 import com.zhangke.fread.status.screen.IStatusScreenProvider
 import com.zhangke.fread.status.uri.FormalUri
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.parameter.parametersOf
 
 class BlueskyScreenProvider(
     private val userUriTransformer: UserUriTransformer,
@@ -150,5 +154,19 @@ class BlueskyScreenProvider(
             locator = account.locator,
             defaultText = text,
         )
+    }
+
+    override fun getUserDetailContent(account: LoggedAccount): (@Composable () -> Unit)? {
+        if (account !is BlueskyLoggedAccount) return null
+        val locator = account.locator
+        val did = account.did
+        return {
+            BskyUserDetailScreen(
+                locator = locator,
+                did = did,
+                viewModel = koinViewModel { parametersOf(locator, did) },
+                showBackButton = false,
+            )
+        }
     }
 }

--- a/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/internal/screen/user/detail/BskyUserDetailScreen.kt
+++ b/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/internal/screen/user/detail/BskyUserDetailScreen.kt
@@ -75,6 +75,7 @@ fun BskyUserDetailScreen(
     locator: PlatformLocator,
     did: String,
     viewModel: BskyUserDetailViewModel,
+    showBackButton: Boolean = true,
 ) {
     val backStack = LocalNavBackStack.currentOrThrow
     val browserLauncher = LocalActivityBrowserLauncher.current
@@ -86,6 +87,7 @@ fun BskyUserDetailScreen(
         uiState = uiState,
         snackbarHostState = snackBarState,
         locator = locator,
+        showBackButton = showBackButton,
         onBackClick = backStack::removeLastOrNull,
         onSearchClick = {
             backStack.add(SearchStatusScreenNavKey(locator = locator, did = did))
@@ -167,7 +169,9 @@ fun BskyUserDetailScreen(
     )
     ConsumeSnackbarFlow(snackBarState, viewModel.snackBarMessage)
     LaunchedEffect(Unit) { viewModel.onPageResume() }
-    ConsumeFlow(viewModel.finishPageFlow) { backStack.removeLastOrNull() }
+    if (showBackButton) {
+        ConsumeFlow(viewModel.finishPageFlow) { backStack.removeLastOrNull() }
+    }
 }
 
 @Composable
@@ -175,6 +179,7 @@ private fun UserDetailContent(
     uiState: BskyUserDetailUiState,
     snackbarHostState: SnackbarHostState,
     locator: PlatformLocator,
+    showBackButton: Boolean,
     onBackClick: () -> Unit,
     onSearchClick: () -> Unit,
     onBannerClick: () -> Unit,
@@ -216,6 +221,7 @@ private fun UserDetailContent(
         onUrlClick = {},
         onMaybeHashtagClick = onHashtagClick,
         onBackClick = onBackClick,
+        showBackButton = showBackButton,
         topBarActions = {
             TopBarActions(
                 uiState = uiState,


### PR DESCRIPTION
If there is one profile added, add the ability to show the user profile view in the fragment instead of the account list view. This is configurable under a new toggle called "Jump to profile" under Behavior in the settings. Settings can still be accessed via hamburger menu.