### PR TITLE
Unread notifications counter badge

### DIFF
--- a/app-hosting/src/commonMain/kotlin/com/zhangke/fread/screen/FreadScreen.kt
+++ b/app-hosting/src/commonMain/kotlin/com/zhangke/fread/screen/FreadScreen.kt
@@ -12,6 +12,8 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.Icon
@@ -19,6 +21,7 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.ModalNavigationDrawer
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -220,10 +223,26 @@ private fun RowScope.TabNavigationItem(
         },
         alwaysShowLabel = false,
         icon = {
-            Icon(
-                painter = tab.options!!.icon!!,
-                contentDescription = tab.options!!.title,
-            )
+            val unreadCount = tab.options?.unreadCountFlow?.collectAsState()?.value ?: 0
+            BadgedBox(
+                badge = {
+                    if (unreadCount > 0) {
+                        Badge(
+                            containerColor = MaterialTheme.colorScheme.onPrimary,
+                            contentColor = MaterialTheme.colorScheme.primary,
+                        ) {
+                            Text(
+                                text = if (unreadCount > 99) "99+" else unreadCount.toString(),
+                            )
+                        }
+                    }
+                },
+            ) {
+                Icon(
+                    painter = tab.options!!.icon!!,
+                    contentDescription = tab.options!!.title,
+                )
+            }
         },
     )
 }

--- a/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/notification/NotificationResolver.kt
+++ b/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/notification/NotificationResolver.kt
@@ -53,6 +53,12 @@ class NotificationResolver(
             it.updateUnreadNotification(account, notificationLastReadId)
         }
     }
+
+    suspend fun getUnreadNotificationsCount(account: LoggedAccount): Result<Int> {
+        return resolverList.firstNotNullOfOrNull {
+            it.getUnreadNotificationsCount(account)
+        } ?: Result.success(0)
+    }
 }
 
 interface INotificationResolver {
@@ -89,4 +95,8 @@ interface INotificationResolver {
         account: LoggedAccount,
         notificationLastReadId: String,
     ): Result<Unit>?
+
+    suspend fun getUnreadNotificationsCount(account: LoggedAccount): Result<Int>? {
+        return null
+    }
 }

--- a/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/CommonModule.kt
+++ b/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/CommonModule.kt
@@ -17,6 +17,7 @@ import com.zhangke.fread.common.deeplink.SelectAccountForPublishViewModel
 import com.zhangke.fread.common.deeplink.SelectedContentSwitcher
 import com.zhangke.fread.common.di.ApplicationCoroutineScope
 import com.zhangke.fread.common.mixed.MixedStatusRepo
+import com.zhangke.fread.common.notification.NotificationUnreadCounter
 import com.zhangke.fread.common.onboarding.OnboardingComponent
 import com.zhangke.fread.common.publish.PublishPostManager
 import com.zhangke.fread.common.repo.LinkPreviewCardRepo
@@ -46,6 +47,7 @@ val commonModule = module {
     singleOf(::DayNightHelper)
     singleOf(::FreadConfigManager)
     singleOf(::FreadReviewManager)
+    singleOf(::NotificationUnreadCounter)
     singleOf(::LocalConfigManager)
     singleOf(::OnboardingComponent)
     singleOf(::PublishPostManager)

--- a/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/notification/NotificationUnreadCounter.kt
+++ b/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/notification/NotificationUnreadCounter.kt
@@ -1,0 +1,61 @@
+package com.zhangke.fread.common.notification
+
+import com.zhangke.fread.common.di.ApplicationCoroutineScope
+import com.zhangke.fread.status.StatusProvider
+import com.zhangke.fread.status.account.LoggedAccount
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+class NotificationUnreadCounter(
+    private val statusProvider: StatusProvider,
+    private val applicationScope: ApplicationCoroutineScope,
+) {
+
+    private val _totalUnreadFlow = MutableStateFlow(0)
+    val totalUnreadFlow: StateFlow<Int> get() = _totalUnreadFlow.asStateFlow()
+
+    private val refreshMutex = Mutex()
+
+    init {
+        applicationScope.launch {
+            statusProvider.accountManager.getAllAccountFlow().collect { accounts ->
+                refreshInternal(accounts)
+            }
+        }
+    }
+
+    fun refresh() {
+        applicationScope.launch {
+            val accounts = statusProvider.accountManager.getAllLoggedAccount()
+            refreshInternal(accounts)
+        }
+    }
+
+    private suspend fun refreshInternal(accounts: List<LoggedAccount>) {
+        refreshMutex.withLock {
+            if (accounts.isEmpty()) {
+                _totalUnreadFlow.value = 0
+                return
+            }
+            val total = supervisorScope {
+                accounts.map { account ->
+                    async {
+                        runCatching {
+                            statusProvider.notificationResolver
+                                .getUnreadNotificationsCount(account)
+                                .getOrDefault(0)
+                        }.getOrDefault(0)
+                    }
+                }.awaitAll().sum()
+            }
+            _totalUnreadFlow.value = total
+        }
+    }
+}

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/home/NotificationsTab.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/home/NotificationsTab.kt
@@ -4,19 +4,23 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import com.zhangke.framework.nav.BaseTab
 import com.zhangke.framework.nav.TabOptions
+import com.zhangke.fread.common.notification.NotificationUnreadCounter
 import com.zhangke.fread.feature.notifications.Res
 import com.zhangke.fread.feature.notifications.ic_notification_tab
 import org.jetbrains.compose.resources.painterResource
+import org.koin.compose.koinInject
 
 class NotificationsTab : BaseTab() {
 
     override val options: TabOptions
         @Composable get() {
             val icon = painterResource(Res.drawable.ic_notification_tab)
-            return remember {
+            val unreadCounter: NotificationUnreadCounter = koinInject()
+            return remember(icon, unreadCounter) {
                 TabOptions(
                     title = "Notifications",
                     icon = icon,
+                    unreadCountFlow = unreadCounter.totalUnreadFlow,
                 )
             }
         }

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationContainerViewModel.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationContainerViewModel.kt
@@ -3,6 +3,7 @@ package com.zhangke.fread.feature.message.screens.notification
 import com.zhangke.framework.lifecycle.ContainerViewModel
 import com.zhangke.framework.lifecycle.ContainerViewModel.SubViewModelParams
 import com.zhangke.fread.common.adapter.StatusUiStateAdapter
+import com.zhangke.fread.common.notification.NotificationUnreadCounter
 import com.zhangke.fread.common.status.StatusUpdater
 import com.zhangke.fread.commonbiz.shared.usecase.RefactorToNewStatusUseCase
 import com.zhangke.fread.feature.message.repo.notification.NotificationsRepo
@@ -15,6 +16,7 @@ class NotificationContainerViewModel(
     private val statusUiStateAdapter: StatusUiStateAdapter,
     private val refactorToNewStatus: RefactorToNewStatusUseCase,
     private val statusUpdater: StatusUpdater,
+    private val notificationUnreadCounter: NotificationUnreadCounter,
 ) : ContainerViewModel<NotificationViewModel, NotificationContainerViewModel.Params>() {
 
     fun getSubViewModel(
@@ -33,6 +35,7 @@ class NotificationContainerViewModel(
             statusUiStateAdapter = statusUiStateAdapter,
             refactorToNewStatus = refactorToNewStatus,
             statusUpdater = statusUpdater,
+            notificationUnreadCounter = notificationUnreadCounter,
         )
     }
 

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
@@ -7,6 +7,7 @@ import com.zhangke.framework.controller.LoadableController
 import com.zhangke.framework.ktx.launchInViewModel
 import com.zhangke.framework.lifecycle.SubViewModel
 import com.zhangke.fread.common.adapter.StatusUiStateAdapter
+import com.zhangke.fread.common.notification.NotificationUnreadCounter
 import com.zhangke.fread.common.status.StatusUpdater
 import com.zhangke.fread.commonbiz.shared.feeds.IInteractiveHandler
 import com.zhangke.fread.commonbiz.shared.feeds.InteractiveHandleResult
@@ -31,6 +32,7 @@ class NotificationViewModel(
     private val statusUiStateAdapter: StatusUiStateAdapter,
     private val refactorToNewStatus: RefactorToNewStatusUseCase,
     private val notificationsRepo: NotificationsRepo,
+    private val notificationUnreadCounter: NotificationUnreadCounter,
     statusUpdater: StatusUpdater,
 ) : SubViewModel(), IInteractiveHandler by InteractiveHandler(
     statusProvider = statusProvider,
@@ -143,6 +145,7 @@ class NotificationViewModel(
                     account = account,
                     notificationLastReadId = firstNotificationId
                 )
+            notificationUnreadCounter.refresh()
         }
     }
 

--- a/framework/src/commonMain/kotlin/com/zhangke/framework/nav/Tab.kt
+++ b/framework/src/commonMain/kotlin/com/zhangke/framework/nav/Tab.kt
@@ -23,6 +23,7 @@ import com.zhangke.framework.composable.plusTopPadding
 import com.zhangke.framework.utils.pxToDp
 import com.zhangke.framework.utils.roundToPx
 import com.zhangke.framework.utils.toPx
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
 
@@ -45,7 +46,8 @@ abstract class BaseTab : Tab {
 
 data class TabOptions(
     val title: String,
-    val icon: Painter? = null
+    val icon: Painter? = null,
+    val unreadCountFlow: StateFlow<Int>? = null,
 )
 
 @Composable

--- a/plugins/activitypub-app/src/commonMain/kotlin/com/zhangke/fread/activitypub/app/ActivityPubNotificationResolver.kt
+++ b/plugins/activitypub-app/src/commonMain/kotlin/com/zhangke/fread/activitypub/app/ActivityPubNotificationResolver.kt
@@ -355,4 +355,13 @@ class ActivityPubNotificationResolver (
             .saveMarkers(notificationLastReadId = notificationLastReadId)
             .map { }
     }
+
+    override suspend fun getUnreadNotificationsCount(account: LoggedAccount): Result<Int>? {
+        if (account.platform.protocol.notActivityPub) return null
+        val role = PlatformLocator(baseUrl = account.platform.baseUrl, accountUri = account.uri)
+        return clientManager.getClient(role)
+            .notificationsRepo
+            .getUnreadNotificationCount(limit = 1000)
+            .map { it.count }
+    }
 }

--- a/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyNotificationResolver.kt
+++ b/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyNotificationResolver.kt
@@ -99,4 +99,13 @@ class BlueskyNotificationResolver(
         return client.updateSeenCatching(UpdateSeenRequest(Clock.System.now()))
             .map { }
     }
+
+    override suspend fun getUnreadNotificationsCount(account: LoggedAccount): Result<Int>? {
+        if (account !is BlueskyLoggedAccount) return null
+        return getNotifications(
+            account = account,
+            type = INotificationResolver.NotificationRequestType.ALL,
+            cursor = null,
+        )?.map { paged -> paged.notifications.count { it.unread } }
+    }
 }


### PR DESCRIPTION
Show an unread notifications counter badge, refreshes state on: 

- app start
- when adding accounts 
- after marking as read the current list from the notifications view

<img width="1080" height="369" alt="Screenshot_20260509-003755_1" src="https://github.com/user-attachments/assets/5e9b848a-171f-4dc4-8882-e4f18bd8ba4f" />
