### PR TITLE
Fix for quote posts missing original post below

### DIFF
--- a/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/BlogContent.kt
+++ b/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/BlogContent.kt
@@ -131,7 +131,8 @@ fun BlogContent(
                     onVoted(it)
                 },
             )
-        } else if (blog.mediaList.isNotEmpty()) {
+        }
+        if (blog.poll == null && blog.mediaList.isNotEmpty()) {
             BlogMedias(
                 modifier = Modifier
                     .padding(top = style.contentStyle.contentVerticalSpacing)
@@ -143,7 +144,8 @@ fun BlogContent(
                 sensitive = sensitive,
                 onMediaClick = onMediaClick,
             )
-        } else if (blog.embeds.isNotEmpty()) {
+        }
+        if (blog.poll == null && blog.embeds.isNotEmpty()) {
             BlogEmbedsUi(
                 modifier = Modifier
                     .padding(top = style.contentStyle.contentVerticalSpacing)


### PR DESCRIPTION
In quote posts, this fix now shows the original post if the quote post is a video. Before it was being shown as a regular post.