### PR TITLE
Following feed filters for bluesky

### DIFF
--- a/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/StatusProvider.kt
+++ b/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/StatusProvider.kt
@@ -8,6 +8,8 @@ import com.zhangke.fread.status.notification.INotificationResolver
 import com.zhangke.fread.status.notification.NotificationResolver
 import com.zhangke.fread.status.platform.IPlatformResolver
 import com.zhangke.fread.status.platform.PlatformResolver
+import com.zhangke.fread.status.preference.FeedPreferencesProvider
+import com.zhangke.fread.status.preference.IFeedPreferencesProvider
 import com.zhangke.fread.status.publish.IPublishBlogManager
 import com.zhangke.fread.status.publish.PublishBlogManager
 import com.zhangke.fread.status.screen.IStatusScreenProvider
@@ -39,6 +41,8 @@ class StatusProvider(private val providers: List<IStatusProvider>) {
     val notificationResolver = NotificationResolver(providers.map { it.notificationResolver })
 
     val publishManager = PublishBlogManager(providers.map { it.publishManager })
+
+    val feedPreferencesProvider = FeedPreferencesProvider(providers.map { it.feedPreferencesProvider })
 }
 
 interface IStatusProvider {
@@ -58,4 +62,7 @@ interface IStatusProvider {
     val notificationResolver: INotificationResolver
 
     val publishManager: IPublishBlogManager
+
+    val feedPreferencesProvider: IFeedPreferencesProvider
+        get() = object : IFeedPreferencesProvider {}
 }

--- a/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/preference/FeedPreferencesProvider.kt
+++ b/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/preference/FeedPreferencesProvider.kt
@@ -1,0 +1,49 @@
+package com.zhangke.fread.status.preference
+
+import com.zhangke.fread.status.account.LoggedAccount
+
+data class FollowingFeedPrefs(
+    val hideReplies: Boolean = false,
+    val hideRepliesByUnfollowed: Boolean = false,
+    val hideReposts: Boolean = false,
+    val hideQuotePosts: Boolean = false,
+)
+
+interface IFeedPreferencesProvider {
+
+    /**
+     * Returns the current Following-feed preferences for the given account.
+     * Returns null when the platform does not expose server-side feed prefs.
+     */
+    suspend fun getFollowingFeedPrefs(account: LoggedAccount): Result<FollowingFeedPrefs>? {
+        return null
+    }
+
+    /**
+     * Persists [prefs] for [account]. Returns null when the platform does not
+     * support server-side feed prefs.
+     */
+    suspend fun updateFollowingFeedPrefs(
+        account: LoggedAccount,
+        prefs: FollowingFeedPrefs,
+    ): Result<Unit>? {
+        return null
+    }
+}
+
+class FeedPreferencesProvider(
+    private val providers: List<IFeedPreferencesProvider>,
+) {
+
+    suspend fun getFollowingFeedPrefs(account: LoggedAccount): Result<FollowingFeedPrefs>? {
+        return providers.firstNotNullOfOrNull { it.getFollowingFeedPrefs(account) }
+    }
+
+    suspend fun updateFollowingFeedPrefs(
+        account: LoggedAccount,
+        prefs: FollowingFeedPrefs,
+    ): Result<Unit> {
+        return providers.firstNotNullOfOrNull { it.updateFollowingFeedPrefs(account, prefs) }
+            ?: Result.success(Unit)
+    }
+}

--- a/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsScreen.kt
+++ b/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsScreen.kt
@@ -1,19 +1,30 @@
 package com.zhangke.fread.profile.screen.setting.behavior
 
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Reply
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.FormatQuote
 import androidx.compose.material.icons.filled.OpenInBrowser
+import androidx.compose.material.icons.filled.PersonOff
 import androidx.compose.material.icons.filled.PlayCircleOutline
+import androidx.compose.material.icons.filled.Repeat
 import androidx.compose.material.icons.filled.ViewTimeline
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import androidx.navigation3.runtime.NavKey
 import com.zhangke.framework.composable.Toolbar
 import com.zhangke.framework.composable.currentOrThrow
@@ -23,6 +34,7 @@ import com.zhangke.fread.localization.LocalizedString
 import com.zhangke.fread.profile.screen.setting.SettingItemWithPopup
 import com.zhangke.fread.profile.screen.setting.SettingItemWithSwitch
 import com.zhangke.fread.profile.screen.setting.displayName
+import com.zhangke.fread.status.preference.FollowingFeedPrefs
 import kotlinx.serialization.Serializable
 import org.jetbrains.compose.resources.stringResource
 
@@ -42,6 +54,7 @@ fun BehaviorSettingsScreen(viewModel: BehaviorSettingsViewModel) {
         onTimelineDefaultPositionChanged = viewModel::onTimelineDefaultPositionChanged,
         onOpenUrlInAppBrowserChanged = viewModel::onOpenUrlInAppBrowserChanged,
         onJumpToProfileChanged = viewModel::onJumpToProfileChanged,
+        onFollowingFeedPrefsChanged = viewModel::onFollowingFeedPrefsChanged,
     )
 }
 
@@ -54,6 +67,7 @@ private fun BehaviorSettingsContent(
     onTimelineDefaultPositionChanged: (TimelineDefaultPosition) -> Unit,
     onOpenUrlInAppBrowserChanged: (Boolean) -> Unit,
     onJumpToProfileChanged: (Boolean) -> Unit,
+    onFollowingFeedPrefsChanged: (FollowingFeedPrefs) -> Unit,
 ) {
     Scaffold(
         topBar = {
@@ -88,6 +102,12 @@ private fun BehaviorSettingsContent(
                 jumpToProfile = uiState.jumpToProfile,
                 onJumpToProfileChanged = onJumpToProfileChanged,
             )
+            if (uiState.showFollowingFeedSection) {
+                FollowingFeedSection(
+                    prefs = uiState.followingFeedPrefs,
+                    onPrefsChanged = onFollowingFeedPrefsChanged,
+                )
+            }
         }
     }
 }
@@ -103,6 +123,57 @@ private fun JumpToProfileItem(
         subtitle = stringResource(LocalizedString.setting_item_jump_to_profile_subtitle),
         checked = jumpToProfile,
         onCheckedChangeRequest = onJumpToProfileChanged,
+    )
+}
+
+@Composable
+private fun FollowingFeedSection(
+    prefs: FollowingFeedPrefs,
+    onPrefsChanged: (FollowingFeedPrefs) -> Unit,
+) {
+    Spacer(modifier = Modifier.height(8.dp))
+    HorizontalDivider()
+    Column(modifier = Modifier.padding(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 4.dp)) {
+        Text(
+            text = stringResource(LocalizedString.setting_group_following_feed_title),
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(modifier = Modifier.height(2.dp))
+        Text(
+            text = stringResource(LocalizedString.setting_group_following_feed_subtitle),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+    }
+    SettingItemWithSwitch(
+        icon = Icons.AutoMirrored.Filled.Reply,
+        title = stringResource(LocalizedString.setting_item_hide_replies_title),
+        subtitle = stringResource(LocalizedString.setting_item_hide_replies_subtitle),
+        checked = prefs.hideReplies,
+        onCheckedChangeRequest = { onPrefsChanged(prefs.copy(hideReplies = it)) },
+    )
+    SettingItemWithSwitch(
+        icon = Icons.Default.PersonOff,
+        title = stringResource(LocalizedString.setting_item_hide_replies_by_unfollowed_title),
+        subtitle = stringResource(LocalizedString.setting_item_hide_replies_by_unfollowed_subtitle),
+        checked = prefs.hideRepliesByUnfollowed,
+        onCheckedChangeRequest = { onPrefsChanged(prefs.copy(hideRepliesByUnfollowed = it)) },
+    )
+    SettingItemWithSwitch(
+        icon = Icons.Default.Repeat,
+        title = stringResource(LocalizedString.setting_item_hide_reposts_title),
+        subtitle = stringResource(LocalizedString.setting_item_hide_reposts_subtitle),
+        checked = prefs.hideReposts,
+        onCheckedChangeRequest = { onPrefsChanged(prefs.copy(hideReposts = it)) },
+    )
+    SettingItemWithSwitch(
+        icon = Icons.Default.FormatQuote,
+        title = stringResource(LocalizedString.setting_item_hide_quote_posts_title),
+        subtitle = stringResource(LocalizedString.setting_item_hide_quote_posts_subtitle),
+        checked = prefs.hideQuotePosts,
+        onCheckedChangeRequest = { onPrefsChanged(prefs.copy(hideQuotePosts = it)) },
     )
 }
 

--- a/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsUiState.kt
+++ b/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsUiState.kt
@@ -1,6 +1,7 @@
 package com.zhangke.fread.profile.screen.setting.behavior
 
 import com.zhangke.fread.common.config.TimelineDefaultPosition
+import com.zhangke.fread.status.preference.FollowingFeedPrefs
 
 data class BehaviorSettingsUiState(
     val autoPlayInlineVideo: Boolean,
@@ -8,4 +9,6 @@ data class BehaviorSettingsUiState(
     val timelineDefaultPosition: TimelineDefaultPosition,
     val openUrlInAppBrowser: Boolean,
     val jumpToProfile: Boolean,
+    val showFollowingFeedSection: Boolean = false,
+    val followingFeedPrefs: FollowingFeedPrefs = FollowingFeedPrefs(),
 )

--- a/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsViewModel.kt
+++ b/feature/profile/src/commonMain/kotlin/com/zhangke/fread/profile/screen/setting/behavior/BehaviorSettingsViewModel.kt
@@ -4,6 +4,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.zhangke.fread.common.config.FreadConfigManager
 import com.zhangke.fread.common.config.TimelineDefaultPosition
+import com.zhangke.fread.status.StatusProvider
+import com.zhangke.fread.status.account.LoggedAccount
+import com.zhangke.fread.status.preference.FollowingFeedPrefs
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -11,6 +14,7 @@ import kotlinx.coroutines.launch
 
 class BehaviorSettingsViewModel(
     private val freadConfigManager: FreadConfigManager,
+    private val statusProvider: StatusProvider,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(
@@ -23,6 +27,8 @@ class BehaviorSettingsViewModel(
         )
     )
     val uiState = _uiState.asStateFlow()
+
+    private var followingFeedAccounts: List<LoggedAccount> = emptyList()
 
     init {
         viewModelScope.launch {
@@ -37,6 +43,26 @@ class BehaviorSettingsViewModel(
                     it.copy(alwaysShowSensitiveContent = config.alwaysShowSensitiveContent)
                 }
             }
+        }
+        viewModelScope.launch { loadFollowingFeedPrefs() }
+    }
+
+    private suspend fun loadFollowingFeedPrefs() {
+        val accounts = statusProvider.accountManager.getAllLoggedAccount()
+        val supported = accounts.mapNotNull { account ->
+            val prefs = statusProvider.feedPreferencesProvider
+                .getFollowingFeedPrefs(account)
+                ?.getOrNull()
+            if (prefs != null) account to prefs else null
+        }
+        if (supported.isEmpty()) return
+        followingFeedAccounts = supported.map { it.first }
+        val firstPrefs = supported.first().second
+        _uiState.update {
+            it.copy(
+                showFollowingFeedSection = true,
+                followingFeedPrefs = firstPrefs,
+            )
         }
     }
 
@@ -71,6 +97,16 @@ class BehaviorSettingsViewModel(
         viewModelScope.launch {
             freadConfigManager.updateJumpToProfile(on)
             _uiState.update { it.copy(jumpToProfile = on) }
+        }
+    }
+
+    fun onFollowingFeedPrefsChanged(prefs: FollowingFeedPrefs) {
+        _uiState.update { it.copy(followingFeedPrefs = prefs) }
+        viewModelScope.launch {
+            followingFeedAccounts.forEach { account ->
+                statusProvider.feedPreferencesProvider
+                    .updateFollowingFeedPrefs(account, prefs)
+            }
         }
     }
 }

--- a/localization/src/commonMain/composeResources/values/strings.xml
+++ b/localization/src/commonMain/composeResources/values/strings.xml
@@ -255,4 +255,14 @@
     <string name="setting_item_solid_bar_background_subtitle">Make the top and bottom bars solid instead of blurred.</string>
     <string name="setting_item_jump_to_profile_title">Jump to profile</string>
     <string name="setting_item_jump_to_profile_subtitle">Jump directly to your profile if there is only one added</string>
+    <string name="setting_group_following_feed_title">Following feed (Bluesky)</string>
+    <string name="setting_group_following_feed_subtitle">Filters synced with the Bluesky network. Affects all clients.</string>
+    <string name="setting_item_hide_replies_title">Hide replies</string>
+    <string name="setting_item_hide_replies_subtitle">Filter out any replies in the Following feed.</string>
+    <string name="setting_item_hide_replies_by_unfollowed_title">Hide replies to non-followed accounts</string>
+    <string name="setting_item_hide_replies_by_unfollowed_subtitle">Filter out replies whose parent post is by someone you don't follow.</string>
+    <string name="setting_item_hide_reposts_title">Hide reposts</string>
+    <string name="setting_item_hide_reposts_subtitle">Filter out reposts in the Following feed.</string>
+    <string name="setting_item_hide_quote_posts_title">Hide quote posts</string>
+    <string name="setting_item_hide_quote_posts_subtitle">Filter out quote posts in the Following feed.</string>
 </resources>

--- a/localization/src/commonMain/kotlin/com/zhangke/fread/localization/LocalizedString.kt
+++ b/localization/src/commonMain/kotlin/com/zhangke/fread/localization/LocalizedString.kt
@@ -662,4 +662,24 @@ object LocalizedString {
         localizedString.setting_item_jump_to_profile_title
     val setting_item_jump_to_profile_subtitle =
         localizedString.setting_item_jump_to_profile_subtitle
+    val setting_group_following_feed_title =
+        localizedString.setting_group_following_feed_title
+    val setting_group_following_feed_subtitle =
+        localizedString.setting_group_following_feed_subtitle
+    val setting_item_hide_replies_title =
+        localizedString.setting_item_hide_replies_title
+    val setting_item_hide_replies_subtitle =
+        localizedString.setting_item_hide_replies_subtitle
+    val setting_item_hide_replies_by_unfollowed_title =
+        localizedString.setting_item_hide_replies_by_unfollowed_title
+    val setting_item_hide_replies_by_unfollowed_subtitle =
+        localizedString.setting_item_hide_replies_by_unfollowed_subtitle
+    val setting_item_hide_reposts_title =
+        localizedString.setting_item_hide_reposts_title
+    val setting_item_hide_reposts_subtitle =
+        localizedString.setting_item_hide_reposts_subtitle
+    val setting_item_hide_quote_posts_title =
+        localizedString.setting_item_hide_quote_posts_title
+    val setting_item_hide_quote_posts_subtitle =
+        localizedString.setting_item_hide_quote_posts_subtitle
 }

--- a/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyFeedPreferencesProvider.kt
+++ b/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyFeedPreferencesProvider.kt
@@ -1,0 +1,77 @@
+package com.zhangke.fread.bluesky
+
+import app.bsky.actor.FeedViewPref
+import app.bsky.actor.PreferencesUnion
+import com.zhangke.framework.utils.exceptionOrThrow
+import com.zhangke.fread.bluesky.internal.account.BlueskyLoggedAccount
+import com.zhangke.fread.bluesky.internal.client.BlueskyClientManager
+import com.zhangke.fread.bluesky.internal.usecase.UpdatePreferencesUseCase
+import com.zhangke.fread.status.account.LoggedAccount
+import com.zhangke.fread.status.preference.FollowingFeedPrefs
+import com.zhangke.fread.status.preference.IFeedPreferencesProvider
+
+private const val HOME_FEED_ID = "home"
+
+class BlueskyFeedPreferencesProvider(
+    private val clientManager: BlueskyClientManager,
+    private val updatePreferences: UpdatePreferencesUseCase,
+) : IFeedPreferencesProvider {
+
+    override suspend fun getFollowingFeedPrefs(
+        account: LoggedAccount,
+    ): Result<FollowingFeedPrefs>? {
+        if (account !is BlueskyLoggedAccount) return null
+        val client = clientManager.getClient(account.locator)
+        val response = client.getPreferencesCatching()
+        if (response.isFailure) {
+            return Result.failure(response.exceptionOrThrow())
+        }
+        val pref = response.getOrThrow()
+            .preferences
+            .filterIsInstance<PreferencesUnion.FeedViewPref>()
+            .firstOrNull { it.value.feed == HOME_FEED_ID }
+            ?.value
+        return Result.success(pref?.toFollowingFeedPrefs() ?: FollowingFeedPrefs())
+    }
+
+    override suspend fun updateFollowingFeedPrefs(
+        account: LoggedAccount,
+        prefs: FollowingFeedPrefs,
+    ): Result<Unit>? {
+        if (account !is BlueskyLoggedAccount) return null
+        return updatePreferences(account.locator) { current ->
+            val updatedHome = PreferencesUnion.FeedViewPref(
+                value = current
+                    .filterIsInstance<PreferencesUnion.FeedViewPref>()
+                    .firstOrNull { it.value.feed == HOME_FEED_ID }
+                    ?.value
+                    ?.copy(
+                        hideReplies = prefs.hideReplies,
+                        hideRepliesByUnfollowed = prefs.hideRepliesByUnfollowed,
+                        hideReposts = prefs.hideReposts,
+                        hideQuotePosts = prefs.hideQuotePosts,
+                    )
+                    ?: FeedViewPref(
+                        feed = HOME_FEED_ID,
+                        hideReplies = prefs.hideReplies,
+                        hideRepliesByUnfollowed = prefs.hideRepliesByUnfollowed,
+                        hideRepliesByLikeCount = null,
+                        hideReposts = prefs.hideReposts,
+                        hideQuotePosts = prefs.hideQuotePosts,
+                    ),
+            )
+            current.filter {
+                !(it is PreferencesUnion.FeedViewPref && it.value.feed == HOME_FEED_ID)
+            } + updatedHome
+        }
+    }
+
+    private fun FeedViewPref.toFollowingFeedPrefs(): FollowingFeedPrefs {
+        return FollowingFeedPrefs(
+            hideReplies = hideReplies == true,
+            hideRepliesByUnfollowed = hideRepliesByUnfollowed == true,
+            hideReposts = hideReposts == true,
+            hideQuotePosts = hideQuotePosts == true,
+        )
+    }
+}

--- a/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyModule.kt
+++ b/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyModule.kt
@@ -74,6 +74,7 @@ val blueskyModule = module {
 
     factoryOf(::BlueskyAccountManager)
     factoryOf(::BlueskyPublishManager)
+    factoryOf(::BlueskyFeedPreferencesProvider)
     factoryOf(::BlueskySearchEngine)
     factoryOf(::BlueskyNotificationResolver)
     factoryOf(::BlueskyStatusResolver)

--- a/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyProvider.kt
+++ b/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/BlueskyProvider.kt
@@ -6,6 +6,7 @@ import com.zhangke.fread.status.account.IAccountManager
 import com.zhangke.fread.status.content.IContentManager
 import com.zhangke.fread.status.notification.INotificationResolver
 import com.zhangke.fread.status.platform.IPlatformResolver
+import com.zhangke.fread.status.preference.IFeedPreferencesProvider
 import com.zhangke.fread.status.publish.IPublishBlogManager
 import com.zhangke.fread.status.screen.IStatusScreenProvider
 import com.zhangke.fread.status.search.ISearchEngine
@@ -21,6 +22,7 @@ class BlueskyProvider(
     accountManager: BlueskyAccountManager,
     notificationResolver: BlueskyNotificationResolver,
     blueskyPublishManager: BlueskyPublishManager,
+    feedPreferencesProvider: BlueskyFeedPreferencesProvider,
 ) : IStatusProvider {
 
     override val contentManager: IContentManager = blueskyContentManager
@@ -38,4 +40,6 @@ class BlueskyProvider(
     override val notificationResolver: INotificationResolver = notificationResolver
 
     override val publishManager: IPublishBlogManager = blueskyPublishManager
+
+    override val feedPreferencesProvider: IFeedPreferencesProvider = feedPreferencesProvider
 }

--- a/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/internal/usecase/GetFeedsStatusUseCase.kt
+++ b/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/internal/usecase/GetFeedsStatusUseCase.kt
@@ -1,6 +1,9 @@
 package com.zhangke.fread.bluesky.internal.usecase
 
+import app.bsky.actor.FeedViewPref
+import app.bsky.actor.PreferencesUnion
 import app.bsky.feed.FeedViewPost
+import app.bsky.feed.FeedViewPostReasonUnion
 import app.bsky.feed.GetActorLikesQueryParams
 import app.bsky.feed.GetAuthorFeedFilter
 import app.bsky.feed.GetAuthorFeedQueryParams
@@ -8,11 +11,14 @@ import app.bsky.feed.GetFeedQueryParams
 import app.bsky.feed.GetListFeedQueryParams
 import app.bsky.feed.GetTimelineQueryParams
 import app.bsky.feed.PostView
+import app.bsky.feed.PostViewEmbedUnion
+import app.bsky.feed.ReplyRefParentUnion
 import app.bsky.feed.SearchPostsQueryParams
 import app.bsky.feed.SearchPostsSort
 import com.zhangke.framework.utils.exceptionOrThrow
 import com.zhangke.fread.bluesky.internal.account.BlueskyLoggedAccount
 import com.zhangke.fread.bluesky.internal.adapter.BlueskyStatusAdapter
+import com.zhangke.fread.bluesky.internal.client.BlueskyClient
 import com.zhangke.fread.bluesky.internal.client.BlueskyClientManager
 import com.zhangke.fread.bluesky.internal.model.BlueskyFeeds
 import com.zhangke.fread.bluesky.internal.model.BskyPagingFeeds
@@ -51,8 +57,9 @@ class GetFeedsStatusUseCase(
             }
 
             is BlueskyFeeds.FollowingTimeline -> {
+                val followingPref = client.getFollowingFeedViewPref()
                 client.getTimelineCatching(GetTimelineQueryParams(cursor = cursor))
-                    .map { it.cursor to it.feed }
+                    .map { it.cursor to it.feed.applyFollowingFeedFilter(followingPref, loggedAccount) }
                     .convert(locator, platform, loggedAccount)
             }
 
@@ -130,6 +137,68 @@ class GetFeedsStatusUseCase(
             )
         }
         return Result.success(BskyPagingFeeds(cursor, status))
+    }
+
+    private suspend fun BlueskyClient.getFollowingFeedViewPref(): FeedViewPref? {
+        return getPreferencesCatching().getOrNull()
+            ?.preferences
+            ?.filterIsInstance<PreferencesUnion.FeedViewPref>()
+            ?.firstOrNull { it.value.feed == "home" }
+            ?.value
+    }
+
+    private fun List<FeedViewPost>.applyFollowingFeedFilter(
+        pref: FeedViewPref?,
+        loggedAccount: BlueskyLoggedAccount?,
+    ): List<FeedViewPost> {
+        if (pref == null) return this
+        val hideReposts = pref.hideReposts == true
+        val hideQuotePosts = pref.hideQuotePosts == true
+        val hideReplies = pref.hideReplies == true
+        val hideRepliesByUnfollowed = pref.hideRepliesByUnfollowed == true
+        if (!hideReposts && !hideQuotePosts && !hideReplies && !hideRepliesByUnfollowed) {
+            return this
+        }
+        val loggedDid = loggedAccount?.did
+        return filter { feedPost ->
+            if (hideReposts && feedPost.reason is FeedViewPostReasonUnion.ReasonRepost) {
+                return@filter false
+            }
+            if (hideQuotePosts) {
+                val embed = feedPost.post.embed
+                if (embed is PostViewEmbedUnion.RecordView ||
+                    embed is PostViewEmbedUnion.RecordWithMediaView
+                ) {
+                    return@filter false
+                }
+            }
+            val reply = feedPost.reply
+            if (reply != null) {
+                if (hideReplies) return@filter false
+                if (hideRepliesByUnfollowed) {
+                    when (val parent = reply.parent) {
+                        is ReplyRefParentUnion.PostView -> {
+                            val parentDid = parent.value.author.did.did
+                            val postDid = feedPost.post.author.did.did
+                            // Allow self-reply (replying to own thread) and
+                            // replies targeting the logged-in user.
+                            if (parentDid != postDid && parentDid != loggedDid) {
+                                val followingUri = parent.value.author.viewer?.following?.atUri
+                                if (followingUri.isNullOrEmpty()) return@filter false
+                            }
+                        }
+
+                        is ReplyRefParentUnion.NotFoundPost,
+                        is ReplyRefParentUnion.BlockedPost -> {
+                            return@filter false
+                        }
+
+                        else -> Unit
+                    }
+                }
+            }
+            true
+        }
     }
 
     private fun Result<Pair<String?, List<PostView>>>.convertPostView(


### PR DESCRIPTION
Add a new section under Behavior which mirrors these settings:

<img width="606" height="413" alt="imagen" src="https://github.com/user-attachments/assets/8ab40a9e-6498-45fa-8b26-fb564fdb3efa" />

Still need to work on it a bit more:
- add loading spinner
-  throw Snackbar if the settings cannot be synced
-  better feedback for success of sync...

Need to also confirm if these settings are just "cosmetic" and the web client does some filtering itself before showing the feed, as opposed to the PDS filtering out based on these settings and returning a modified feed in the API.

Hence why this is in draft.