### PR TITLE
Add ability to translate posts

### DIFF
--- a/commonbiz/common/src/androidMain/kotlin/com/zhangke/fread/common/handler/TextHandler.android.kt
+++ b/commonbiz/common/src/androidMain/kotlin/com/zhangke/fread/common/handler/TextHandler.android.kt
@@ -29,6 +29,23 @@ actual class TextHandler (
         ShareHelper.shareUrl(context, url, text)
     }
 
+    actual fun translateText(text: String) {
+        if (text.isBlank()) return
+        val intent = Intent(Intent.ACTION_PROCESS_TEXT).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_PROCESS_TEXT, text)
+            putExtra(Intent.EXTRA_PROCESS_TEXT_READONLY, true)
+        }
+        val chooser = Intent.createChooser(intent, "Translate")
+            .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        if (intent.resolveActivity(context.packageManager) != null) {
+            context.startActivityCompat(chooser)
+        } else {
+            // Fall back to the share sheet so the user can pick a translation app.
+            ShareHelper.shareUrl(context, "", text)
+        }
+    }
+
     actual fun openSendEmail() {
         SystemUtils.copyText(context, AppCommonConfig.AUTHOR_EMAIL)
         val intent = Intent(Intent.ACTION_SEND)

--- a/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/handler/TextHandler.kt
+++ b/commonbiz/common/src/commonMain/kotlin/com/zhangke/fread/common/handler/TextHandler.kt
@@ -14,6 +14,8 @@ expect class TextHandler {
 
     fun shareUrl(url: String, text: String)
 
+    fun translateText(text: String)
+
     fun openSendEmail()
 
     fun openAppMarket()

--- a/commonbiz/common/src/iosMain/kotlin/com/zhangke/fread/common/handler/TextHandler.ios.kt
+++ b/commonbiz/common/src/iosMain/kotlin/com/zhangke/fread/common/handler/TextHandler.ios.kt
@@ -34,6 +34,19 @@ actual class TextHandler () {
         )
     }
 
+    actual fun translateText(text: String) {
+        if (text.isEmpty()) return
+        // iOS doesn't expose a system Translate intent like Android's ACTION_PROCESS_TEXT;
+        // present the share sheet so the user can pick the Translate extension.
+        val activityViewController = UIActivityViewController(listOf(text), null)
+        val rootViewController = UIApplication.sharedApplication.keyWindow?.rootViewController
+        rootViewController?.presentViewController(
+            activityViewController,
+            animated = true,
+            completion = null,
+        )
+    }
+
     actual fun openSendEmail() {
         val mailtoUrl = "mailto:"
         val url = NSURL.URLWithString(mailtoUrl)

--- a/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/action/StatusMoreInteractionPanel.kt
+++ b/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/action/StatusMoreInteractionPanel.kt
@@ -176,14 +176,16 @@ private fun AdditionalMoreOptions(
             onOpenBlogWithOtherAccountClick(blog)
         }
     }
-    if (blogTranslationState.support) {
-        ModalDropdownMenuItem(
-            text = stringResource(LocalizedString.statusUiInteractionTranslate),
-            imageVector = Icons.Default.Language,
-            onClick = {
-                onDismissRequest()
+    ModalDropdownMenuItem(
+        text = stringResource(LocalizedString.statusUiInteractionTranslate),
+        imageVector = Icons.Default.Language,
+        onClick = {
+            onDismissRequest()
+            if (blogTranslationState.support) {
                 onTranslateClick()
-            },
-        )
-    }
+            } else {
+                textHandler.translateText(blog.content)
+            }
+        },
+    )
 }


### PR DESCRIPTION
This PR adds an option to translate post via the 3-dot menu on bluesky posts.

Use Android's `ACTION_PROCESS_TEXT` intent which shows a list of appropiate apps that can translate text (google translate included). 

On iOS, share the text... user has to select the app for translate.

How it works:

| Step 1: click the 3-dot menu, option to translate is there | Click translate, app picker is shown | View translated text via your translation app of choice |
|--------------|---------------|-------------|
| <img height="1000" alt="Screenshot_20260509-154657" src="https://github.com/user-attachments/assets/f7a3b406-5d48-4173-a362-8fca18e3ab39" /> | <img height="1000" alt="Screenshot_20260509-154702" src="https://github.com/user-attachments/assets/a33ae98b-f29f-4db1-bb71-bb34d872c6ff" /> | <img height="1000" alt="Screenshot_20260509-154713" src="https://github.com/user-attachments/assets/ee940c28-f641-43b8-80c4-f999e94d3a58" /> |

Leaves intact the Mastodon/ActivityPub flow.