### PR TITLE
Implement grouped notifications

### DIFF
--- a/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/FollowNotification.kt
+++ b/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/FollowNotification.kt
@@ -1,13 +1,17 @@
 package com.zhangke.fread.commonbiz.shared.notification
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import com.zhangke.fread.commonbiz.shared.composable.UserInfoCard
 import com.zhangke.fread.localization.LocalizedString
 import com.zhangke.fread.status.author.BlogAuthor
 import com.zhangke.fread.status.notification.StatusNotification
@@ -22,29 +26,39 @@ fun FollowNotification(
     onUnfollowAccountClick: (BlogAuthor) -> Unit,
     onUnblockClick: (BlogAuthor) -> Unit,
     onCancelFollowRequestClick: (BlogAuthor) -> Unit,
+    additionalActors: List<BlogAuthor> = emptyList(),
 ) {
+    var expanded by rememberSaveable(notification.id) { mutableStateOf(false) }
+    val expandable = additionalActors.isNotEmpty()
     Column(
         modifier = Modifier.fillMaxWidth()
             .padding(style.containerPaddings),
     ) {
         NotificationHeadLine(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { onUserInfoClick(notification.author) },
             icon = Icons.Default.PersonAdd,
             avatar = notification.author.avatar,
             createAt = notification.formattingDisplayTime,
             accountName = notification.author.humanizedName,
             interactionDesc = stringResource(LocalizedString.sharedNotificationFollowDesc),
             style = style,
+            additionalAvatars = additionalActors.map { it.avatar },
+            othersCount = additionalActors.size,
+            avatarSize = style.triggerAccountAvatarSize * 1.5F,
+            expandable = expandable,
+            expanded = expanded,
+            onToggleExpand = { expanded = !expanded },
         )
-        UserInfoCard(
-            modifier = Modifier.padding(top = style.headLineToContentPadding)
-                .fillMaxWidth(),
-            user = notification.author,
-            onUserClick = onUserInfoClick,
-            onFollowAccountClick = onFollowAccountClick,
-            onUnfollowAccountClick = onUnfollowAccountClick,
-            onUnblockClick = onUnblockClick,
-            onCancelFollowRequestClick = onCancelFollowRequestClick,
-        )
+
+        if (expandable && expanded) {
+            val allActors = listOf(notification.author) + additionalActors
+            NotificationActorsList(
+                modifier = Modifier.padding(top = style.headLineToContentPadding),
+                actors = allActors,
+                onActorClick = onUserInfoClick,
+            )
+        }
     }
 }

--- a/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/FollowNotification.kt
+++ b/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/FollowNotification.kt
@@ -1,17 +1,13 @@
 package com.zhangke.fread.commonbiz.shared.notification
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PersonAdd
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.zhangke.fread.commonbiz.shared.composable.UserInfoCard
 import com.zhangke.fread.localization.LocalizedString
 import com.zhangke.fread.status.author.BlogAuthor
 import com.zhangke.fread.status.notification.StatusNotification
@@ -26,39 +22,29 @@ fun FollowNotification(
     onUnfollowAccountClick: (BlogAuthor) -> Unit,
     onUnblockClick: (BlogAuthor) -> Unit,
     onCancelFollowRequestClick: (BlogAuthor) -> Unit,
-    additionalActors: List<BlogAuthor> = emptyList(),
 ) {
-    var expanded by rememberSaveable(notification.id) { mutableStateOf(false) }
-    val expandable = additionalActors.isNotEmpty()
     Column(
         modifier = Modifier.fillMaxWidth()
             .padding(style.containerPaddings),
     ) {
         NotificationHeadLine(
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { onUserInfoClick(notification.author) },
+            modifier = Modifier.fillMaxWidth(),
             icon = Icons.Default.PersonAdd,
             avatar = notification.author.avatar,
             createAt = notification.formattingDisplayTime,
             accountName = notification.author.humanizedName,
             interactionDesc = stringResource(LocalizedString.sharedNotificationFollowDesc),
             style = style,
-            additionalAvatars = additionalActors.map { it.avatar },
-            othersCount = additionalActors.size,
-            avatarSize = style.triggerAccountAvatarSize * 1.5F,
-            expandable = expandable,
-            expanded = expanded,
-            onToggleExpand = { expanded = !expanded },
         )
-
-        if (expandable && expanded) {
-            val allActors = listOf(notification.author) + additionalActors
-            NotificationActorsList(
-                modifier = Modifier.padding(top = style.headLineToContentPadding),
-                actors = allActors,
-                onActorClick = onUserInfoClick,
-            )
-        }
+        UserInfoCard(
+            modifier = Modifier.padding(top = style.headLineToContentPadding)
+                .fillMaxWidth(),
+            user = notification.author,
+            onUserClick = onUserInfoClick,
+            onFollowAccountClick = onFollowAccountClick,
+            onUnfollowAccountClick = onUnfollowAccountClick,
+            onUnblockClick = onUnblockClick,
+            onCancelFollowRequestClick = onCancelFollowRequestClick,
+        )
     }
 }

--- a/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/NotificationActorsList.kt
+++ b/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/NotificationActorsList.kt
@@ -1,0 +1,61 @@
+package com.zhangke.fread.commonbiz.shared.notification
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.zhangke.fread.status.author.BlogAuthor
+import com.zhangke.fread.status.ui.BlogAuthorAvatar
+
+@Composable
+fun NotificationActorsList(
+    modifier: Modifier,
+    actors: List<BlogAuthor>,
+    onActorClick: (BlogAuthor) -> Unit,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        actors.forEach { author ->
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { onActorClick(author) }
+                    .padding(vertical = 6.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BlogAuthorAvatar(
+                    modifier = Modifier.size(28.dp),
+                    imageUrl = author.avatar,
+                )
+                Spacer(modifier = Modifier.width(10.dp))
+                Text(
+                    text = author.name.ifEmpty { author.prettyHandle.removePrefix("@") },
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    modifier = Modifier.weight(1F),
+                    text = author.prettyHandle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}

--- a/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/NotificationHeadLine.kt
+++ b/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/NotificationHeadLine.kt
@@ -1,9 +1,14 @@
 package com.zhangke.fread.commonbiz.shared.notification
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
@@ -14,6 +19,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.zhangke.framework.composable.TwoTextsInRow
@@ -21,6 +27,8 @@ import com.zhangke.fread.status.model.FormattingTime
 import com.zhangke.fread.status.richtext.RichText
 import com.zhangke.fread.status.ui.BlogAuthorAvatar
 import com.zhangke.fread.status.ui.richtext.FreadRichText
+
+private const val MAX_STACKED_AVATARS = 4
 
 @Composable
 fun NotificationHeadLine(
@@ -32,6 +40,12 @@ fun NotificationHeadLine(
     style: NotificationStyle,
     createAt: FormattingTime,
     iconTint: Color = LocalContentColor.current,
+    additionalAvatars: List<String?> = emptyList(),
+    othersCount: Int = 0,
+    avatarSize: Dp = style.triggerAccountAvatarSize,
+    expandable: Boolean = false,
+    expanded: Boolean = false,
+    onToggleExpand: () -> Unit = {},
 ) {
     Row(
         modifier = modifier.fillMaxWidth(),
@@ -44,15 +58,23 @@ fun NotificationHeadLine(
             tint = iconTint,
         )
 
-        if (!avatar.isNullOrEmpty()) {
-            BlogAuthorAvatar(
-                modifier = Modifier
-                    .padding(start = 6.dp)
-                    .size(style.triggerAccountAvatarSize),
-                imageUrl = avatar,
+        val stack = (listOf(avatar) + additionalAvatars)
+            .filter { !it.isNullOrEmpty() }
+            .take(MAX_STACKED_AVATARS)
+        if (stack.isNotEmpty()) {
+            AvatarStack(
+                modifier = Modifier.padding(start = 6.dp),
+                avatars = stack,
+                avatarSize = avatarSize,
             )
         }
 
+        val displayDesc = if (othersCount > 0) {
+            val plural = if (othersCount == 1) "other" else "others"
+            "and $othersCount $plural $interactionDesc"
+        } else {
+            interactionDesc
+        }
         TwoTextsInRow(
             modifier = Modifier.weight(1F),
             firstText = {
@@ -67,7 +89,7 @@ fun NotificationHeadLine(
             secondText = {
                 Text(
                     modifier = Modifier,
-                    text = interactionDesc,
+                    text = displayDesc,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.labelMedium,
@@ -83,5 +105,40 @@ fun NotificationHeadLine(
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.labelMedium,
         )
+
+        if (expandable) {
+            Icon(
+                modifier = Modifier
+                    .padding(start = 4.dp)
+                    .size(18.dp)
+                    .clickable { onToggleExpand() },
+                imageVector = if (expanded) {
+                    Icons.Default.KeyboardArrowUp
+                } else {
+                    Icons.Default.KeyboardArrowDown
+                },
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AvatarStack(
+    modifier: Modifier,
+    avatars: List<String?>,
+    avatarSize: Dp,
+) {
+    val overlap = avatarSize * 0.35F
+    Box(modifier = modifier) {
+        avatars.forEachIndexed { index, url ->
+            BlogAuthorAvatar(
+                modifier = Modifier
+                    .padding(start = (avatarSize - overlap) * index)
+                    .size(avatarSize),
+                imageUrl = url,
+            )
+        }
     }
 }

--- a/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/NotificationWithWholeStatus.kt
+++ b/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/NotificationWithWholeStatus.kt
@@ -9,6 +9,10 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -33,7 +37,10 @@ fun NotificationWithWholeStatus(
     style: NotificationStyle,
     composedStatusInteraction: ComposedStatusInteraction,
     iconTint: Color = LocalContentColor.current,
+    additionalActors: List<BlogAuthor> = emptyList(),
 ) {
+    var expanded by rememberSaveable(sharedElementId) { mutableStateOf(false) }
+    val expandable = additionalActors.isNotEmpty()
     Column(
         modifier = Modifier
             .clickable { composedStatusInteraction.onBlogClick(locator, blog) }
@@ -51,7 +58,21 @@ fun NotificationWithWholeStatus(
             accountName = author?.humanizedName,
             interactionDesc = interactionDesc,
             style = style,
+            additionalAvatars = additionalActors.map { it.avatar },
+            othersCount = additionalActors.size,
+            expandable = expandable,
+            expanded = expanded,
+            onToggleExpand = { expanded = !expanded },
         )
+
+        if (expandable && expanded) {
+            val allActors = listOfNotNull(author) + additionalActors
+            NotificationActorsList(
+                modifier = Modifier.padding(top = style.headLineToContentPadding),
+                actors = allActors,
+                onActorClick = { composedStatusInteraction.onUserInfoClick(locator, it) },
+            )
+        }
 
         BlogUi(
             modifier = Modifier.padding(top = style.headLineToContentPadding)

--- a/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/StatusNotificationUi.kt
+++ b/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/StatusNotificationUi.kt
@@ -39,6 +39,7 @@ fun StatusNotificationUi(
     onUnblockClick: (PlatformLocator, BlogAuthor) -> Unit,
     onCancelFollowRequestClick: (PlatformLocator, BlogAuthor) -> Unit,
     composedStatusInteraction: ComposedStatusInteraction,
+    additionalActors: List<BlogAuthor> = emptyList(),
 ) {
     Column(modifier = modifier) {
         Box(modifier = Modifier) {
@@ -56,6 +57,7 @@ fun StatusNotificationUi(
                         interactionDesc = stringResource(LocalizedString.sharedNotificationFavouritedDesc),
                         style = style,
                         composedStatusInteraction = composedStatusInteraction,
+                        additionalActors = additionalActors,
                     )
                 }
 
@@ -95,6 +97,7 @@ fun StatusNotificationUi(
                         interactionDesc = stringResource(LocalizedString.sharedNotificationReblogDesc),
                         style = style,
                         composedStatusInteraction = composedStatusInteraction,
+                        additionalActors = additionalActors,
                     )
                 }
 
@@ -130,6 +133,7 @@ fun StatusNotificationUi(
                         onCancelFollowRequestClick = {
                             onCancelFollowRequestClick(notification.locator, it)
                         },
+                        additionalActors = additionalActors,
                     )
                 }
 
@@ -254,9 +258,9 @@ object NotificationStyleDefaults {
     const val nameMaxLength = 10
 
     val containerStartPadding = 16.dp
-    val containerTopPadding = 8.dp
+    val containerTopPadding = 12.dp
     val containerEndPadding = 16.dp
-    val containerBottomPadding = 8.dp
+    val containerBottomPadding = 12.dp
 
     val internalBlogStartPadding = 8.dp
     val internalBlogTopPadding = 8.dp

--- a/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/StatusNotificationUi.kt
+++ b/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/StatusNotificationUi.kt
@@ -133,7 +133,6 @@ fun StatusNotificationUi(
                         onCancelFollowRequestClick = {
                             onCancelFollowRequestClick(notification.locator, it)
                         },
-                        additionalActors = additionalActors,
                     )
                 }
 

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationTab.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationTab.kt
@@ -159,6 +159,7 @@ class NotificationTab(
                                 modifier = Modifier.fillMaxWidth()
                                     .background(backgroundColor),
                                 notification = notification.notification,
+                                additionalActors = notification.additionalActors,
                                 composedStatusInteraction = composedStatusInteraction,
                                 indexInList = index,
                                 onAcceptClick = onAcceptClick,

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationUiState.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationUiState.kt
@@ -4,6 +4,7 @@ import com.zhangke.framework.composable.TextString
 import com.zhangke.framework.controller.LoadableUiState
 import com.zhangke.framework.utils.LoadState
 import com.zhangke.fread.status.account.LoggedAccount
+import com.zhangke.fread.status.author.BlogAuthor
 import com.zhangke.fread.status.model.StatusUiState
 import com.zhangke.fread.status.notification.StatusNotification
 
@@ -55,6 +56,7 @@ data class StatusNotificationUiState(
     val notification: StatusNotification,
     val unreadState: Boolean = notification.unread,
     val fromLocal: Boolean,
+    val additionalActors: List<BlogAuthor> = emptyList(),
 ) {
 
     val id: String get() = notification.id

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
@@ -278,6 +278,7 @@ class NotificationViewModel(
             this.reachEnd = it.reachEnd
             it.notifications
                 .map { n -> StatusNotificationUiState(n, fromLocal = false) }
+                .groupSimilar()
                 .let { list -> fillUserDetails(list, userDetailSnapshot) }
         }.onSuccess {
             if (loadMore || uiState.value.inOnlyMentionTab) {
@@ -365,7 +366,61 @@ class NotificationViewModel(
                 }
             }.sortedByDescending { it.createAt.epochMillis }
             .map { StatusNotificationUiState(it, fromLocal = true) }
+            .groupSimilar()
     }
+
+    /**
+     * Groups consecutive likes/reposts on the same post (and follows) into a single
+     * row, mirroring how the official Bluesky client renders them. The first item in
+     * each group keeps its primary actor; subsequent actors are stashed in
+     * [StatusNotificationUiState.additionalActors] for the avatar stack.
+     */
+    private fun List<StatusNotificationUiState>.groupSimilar(): List<StatusNotificationUiState> {
+        if (isEmpty()) return this
+        val result = mutableListOf<StatusNotificationUiState>()
+        for (item in this) {
+            val key = item.notification.groupKey() ?: run {
+                result += item
+                continue
+            }
+            val existingIndex = result.indexOfFirst { it.notification.groupKey() == key }
+            if (existingIndex < 0) {
+                result += item
+                continue
+            }
+            val existing = result[existingIndex]
+            val newAuthor = item.notification.author ?: continue
+            val primaryAuthor = existing.notification.author
+            val alreadyPresent = primaryAuthor?.uri == newAuthor.uri ||
+                existing.additionalActors.any { it.uri == newAuthor.uri }
+            if (alreadyPresent) continue
+            result[existingIndex] = existing.copy(
+                additionalActors = existing.additionalActors + newAuthor,
+                unreadState = existing.unreadState || item.unreadState,
+            )
+        }
+        return result
+    }
+
+    private fun StatusNotification.groupKey(): String? = when (this) {
+        is StatusNotification.Like -> "like:${blog.id}"
+        is StatusNotification.Repost -> "repost:${blog.id}"
+        is StatusNotification.Follow -> "follow"
+        else -> null
+    }
+
+    private val StatusNotification.author: BlogAuthor?
+        get() = when (this) {
+            is StatusNotification.Like -> author
+            is StatusNotification.Follow -> author
+            is StatusNotification.Repost -> author
+            is StatusNotification.Mention -> author
+            is StatusNotification.Reply -> author
+            is StatusNotification.Quote -> author
+            is StatusNotification.QuoteUpdate -> author
+            is StatusNotification.FollowRequest -> author
+            else -> null
+        }
 
     private suspend fun updateStatus(newStatus: StatusUiState) {
         var updatedNotification: StatusNotification? = null

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
@@ -281,6 +281,7 @@ class NotificationViewModel(
             this.reachEnd = it.reachEnd
             it.notifications
                 .map { n -> StatusNotificationUiState(n, fromLocal = false) }
+                .groupSimilar()
                 .let { list -> fillUserDetails(list, userDetailSnapshot) }
         }.onSuccess {
             if (loadMore || uiState.value.inOnlyMentionTab) {
@@ -368,7 +369,61 @@ class NotificationViewModel(
                 }
             }.sortedByDescending { it.createAt.epochMillis }
             .map { StatusNotificationUiState(it, fromLocal = true) }
+            .groupSimilar()
     }
+
+    /**
+     * Groups consecutive likes/reposts on the same post (and follows) into a single
+     * row, mirroring how the official Bluesky client renders them. The first item in
+     * each group keeps its primary actor; subsequent actors are stashed in
+     * [StatusNotificationUiState.additionalActors] for the avatar stack.
+     */
+    private fun List<StatusNotificationUiState>.groupSimilar(): List<StatusNotificationUiState> {
+        if (isEmpty()) return this
+        val result = mutableListOf<StatusNotificationUiState>()
+        for (item in this) {
+            val key = item.notification.groupKey() ?: run {
+                result += item
+                continue
+            }
+            val existingIndex = result.indexOfFirst { it.notification.groupKey() == key }
+            if (existingIndex < 0) {
+                result += item
+                continue
+            }
+            val existing = result[existingIndex]
+            val newAuthor = item.notification.author ?: continue
+            val primaryAuthor = existing.notification.author
+            val alreadyPresent = primaryAuthor?.uri == newAuthor.uri ||
+                existing.additionalActors.any { it.uri == newAuthor.uri }
+            if (alreadyPresent) continue
+            result[existingIndex] = existing.copy(
+                additionalActors = existing.additionalActors + newAuthor,
+                unreadState = existing.unreadState || item.unreadState,
+            )
+        }
+        return result
+    }
+
+    private fun StatusNotification.groupKey(): String? = when (this) {
+        is StatusNotification.Like -> "like:${blog.id}"
+        is StatusNotification.Repost -> "repost:${blog.id}"
+        is StatusNotification.Follow -> "follow"
+        else -> null
+    }
+
+    private val StatusNotification.author: BlogAuthor?
+        get() = when (this) {
+            is StatusNotification.Like -> author
+            is StatusNotification.Follow -> author
+            is StatusNotification.Repost -> author
+            is StatusNotification.Mention -> author
+            is StatusNotification.Reply -> author
+            is StatusNotification.Quote -> author
+            is StatusNotification.QuoteUpdate -> author
+            is StatusNotification.FollowRequest -> author
+            else -> null
+        }
 
     private suspend fun updateStatus(newStatus: StatusUiState) {
         var updatedNotification: StatusNotification? = null

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
@@ -379,22 +379,19 @@ class NotificationViewModel(
         if (isEmpty()) return this
         val result = mutableListOf<StatusNotificationUiState>()
         for (item in this) {
-            val key = item.notification.groupKey() ?: run {
+            val key = item.notification.groupKey()
+            val lastIndex = result.lastIndex
+            if (key == null || lastIndex < 0 || result[lastIndex].notification.groupKey() != key) {
                 result += item
                 continue
             }
-            val existingIndex = result.indexOfFirst { it.notification.groupKey() == key }
-            if (existingIndex < 0) {
-                result += item
-                continue
-            }
-            val existing = result[existingIndex]
+            val existing = result[lastIndex]
             val newAuthor = item.notification.author ?: continue
             val primaryAuthor = existing.notification.author
             val alreadyPresent = primaryAuthor?.uri == newAuthor.uri ||
                 existing.additionalActors.any { it.uri == newAuthor.uri }
             if (alreadyPresent) continue
-            result[existingIndex] = existing.copy(
+            result[lastIndex] = existing.copy(
                 additionalActors = existing.additionalActors + newAuthor,
                 unreadState = existing.unreadState || item.unreadState,
             )

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
@@ -373,7 +373,7 @@ class NotificationViewModel(
     }
 
     /**
-     * Groups consecutive likes/reposts on the same post (and follows) into a single
+     * Groups consecutive likes/reposts on the same post into a single
      * row, mirroring how the official Bluesky client renders them. The first item in
      * each group keeps its primary actor; subsequent actors are stashed in
      * [StatusNotificationUiState.additionalActors] for the avatar stack.
@@ -405,7 +405,6 @@ class NotificationViewModel(
     private fun StatusNotification.groupKey(): String? = when (this) {
         is StatusNotification.Like -> "like:${blog.id}"
         is StatusNotification.Repost -> "repost:${blog.id}"
-        is StatusNotification.Follow -> "follow"
         else -> null
     }
 

--- a/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
+++ b/feature/notifications/src/commonMain/kotlin/com/zhangke/fread/feature/message/screens/notification/NotificationViewModel.kt
@@ -382,22 +382,19 @@ class NotificationViewModel(
         if (isEmpty()) return this
         val result = mutableListOf<StatusNotificationUiState>()
         for (item in this) {
-            val key = item.notification.groupKey() ?: run {
+            val key = item.notification.groupKey()
+            val lastIndex = result.lastIndex
+            if (key == null || lastIndex < 0 || result[lastIndex].notification.groupKey() != key) {
                 result += item
                 continue
             }
-            val existingIndex = result.indexOfFirst { it.notification.groupKey() == key }
-            if (existingIndex < 0) {
-                result += item
-                continue
-            }
-            val existing = result[existingIndex]
+            val existing = result[lastIndex]
             val newAuthor = item.notification.author ?: continue
             val primaryAuthor = existing.notification.author
             val alreadyPresent = primaryAuthor?.uri == newAuthor.uri ||
                 existing.additionalActors.any { it.uri == newAuthor.uri }
             if (alreadyPresent) continue
-            result[existingIndex] = existing.copy(
+            result[lastIndex] = existing.copy(
                 additionalActors = existing.additionalActors + newAuthor,
                 unreadState = existing.unreadState || item.unreadState,
             )


### PR DESCRIPTION
- Basic grouped notifications by post, closely following how it's done in the official web client
- Slimmer "followed you" notification item for follows, do not show the card, group by follows too
- Collapsable list, expanded by tapping on an arrow, to view single actions on a grouped notification for a post

| How it looked before | How it looks after this branch is applied | Un-collapse a grouped notif to reveal more details |
|----------|-----------|-------------|
| <img height="1000" alt="Screenshot_20260509-144034" src="https://github.com/user-attachments/assets/226200d6-22ed-42a3-a621-d04e49179373" /> | <img  height="1000" alt="Screenshot_20260509-155957" src="https://github.com/user-attachments/assets/afbe8525-c11e-4454-9973-3d293a9d8a01" /> | <img  height="1000"  alt="Screenshot_20260509-160000" src="https://github.com/user-attachments/assets/278d76ca-3bc0-4180-a88d-b32c0b6271dc" /> |