### PR TITLE
Resolve the author's domain when displaying users in search results

### DIFF
--- a/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/author/BlogAuthor.kt
+++ b/bizframework/status-provider/src/commonMain/kotlin/com/zhangke/fread/status/author/BlogAuthor.kt
@@ -49,6 +49,13 @@ data class BlogAuthor(
 
     val prettyHandle: String = handle.prettyHandle()
 
+    val displayHandle: String =
+        if (webFinger.did != null && handle.isNotBlank() && handle != "handle.invalid") {
+            handle.prettyHandle()
+        } else {
+            webFinger.toString()
+        }
+
     private fun getFixedName(): String {
         if (name.isNotEmpty()) return name
         val nameFromHandle = handle.removePrefix("@")

--- a/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/FollowRequestNotification.kt
+++ b/commonbiz/sharedscreen/src/commonMain/kotlin/com/zhangke/fread/commonbiz/shared/notification/FollowRequestNotification.kt
@@ -78,7 +78,7 @@ fun FollowRequestNotification(
                 Text(
                     modifier = Modifier.padding(top = 2.dp),
                     textAlign = TextAlign.Left,
-                    text = notification.author.webFinger.toString(),
+                    text = notification.author.displayHandle,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )

--- a/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/BlogAuthorUi.kt
+++ b/commonbiz/status-ui/src/commonMain/kotlin/com/zhangke/fread/status/ui/BlogAuthorUi.kt
@@ -61,7 +61,7 @@ fun BlogAuthorUi(
                 Text(
                     modifier = Modifier.fillMaxWidth().padding(top = 2.dp),
                     textAlign = TextAlign.Start,
-                    text = author.webFinger.toString(),
+                    text = author.displayHandle,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     style = MaterialTheme.typography.labelMedium,
@@ -144,7 +144,7 @@ private fun BaseBlogAuthor(
                         Text(
                             modifier = Modifier.fillMaxWidth().padding(top = 2.dp),
                             textAlign = TextAlign.Start,
-                            text = author.webFinger.toString(),
+                            text = author.displayHandle,
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                             style = MaterialTheme.typography.labelMedium,


### PR DESCRIPTION
Do not show `did@did:plc:xxxx` in the search results.

| Before | After |
|---------|------|
| <img width="1080" height="1133" alt="Screenshot_20260510-144358" src="https://github.com/user-attachments/assets/3fd937d9-9232-4da9-8dd6-5ffeb73e1b3d" /> | <img width="1080" height="1125" alt="Screenshot_20260510-144945" src="https://github.com/user-attachments/assets/83a56f59-28ee-43eb-b6c6-c7f5b22a92dd" /> |


