### PR TITLE
Fix crash in bluesky feed due to unsupported embed type

### DIFF
--- a/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/internal/usecase/GetFeedsStatusUseCase.kt
+++ b/plugins/bluesky/src/commonMain/kotlin/com/zhangke/fread/bluesky/internal/usecase/GetFeedsStatusUseCase.kt
@@ -121,13 +121,18 @@ class GetFeedsStatusUseCase(
     ): Result<BskyPagingFeeds> {
         if (this.isFailure) return Result.failure(this.exceptionOrThrow())
         val (cursor, feeds) = this.getOrThrow()
-        val status = feeds.map {
-            statusAdapter.convertToUiState(
-                locator = locator,
-                feedViewPost = it,
-                platform = platform,
-                loggedAccount = loggedAccount,
-            )
+        // Convert each post independently: a single post that fails to
+        // deserialize (e.g. an unknown embed $type the ozone lexicon doesn't
+        // know yet) must not take down the whole feed.
+        val status = feeds.mapNotNull {
+            runCatching {
+                statusAdapter.convertToUiState(
+                    locator = locator,
+                    feedViewPost = it,
+                    platform = platform,
+                    loggedAccount = loggedAccount,
+                )
+            }.getOrNull()
         }
         return Result.success(BskyPagingFeeds(cursor, status))
     }
@@ -139,13 +144,15 @@ class GetFeedsStatusUseCase(
     ): Result<BskyPagingFeeds> {
         if (this.isFailure) return Result.failure(this.exceptionOrThrow())
         val (cursor, feeds) = this.getOrThrow()
-        val status = feeds.map {
-            statusAdapter.convertToUiState(
-                locator = locator,
-                postView = it,
-                platform = platform,
-                loggedAccount = loggedAccount,
-            )
+        val status = feeds.mapNotNull {
+            runCatching {
+                statusAdapter.convertToUiState(
+                    locator = locator,
+                    postView = it,
+                    platform = platform,
+                    loggedAccount = loggedAccount,
+                )
+            }.getOrNull()
         }
         return Result.success(BskyPagingFeeds(cursor, status))
     }


### PR DESCRIPTION
Logcat after app crashes:

```java
kotlinx.serialization.json.internal.JsonDecodingException:
Serializer for subclass 'app.bsky.embed.gallery' is not found
in the polymorphic scope of 'PostEmbedUnion'.
```

Due to a post having embed -> $type `app.bsky.embed.gallery`

This is a new type of embed post recently introduced:

https://bsky.app/profile/bsky.app/post/3mnslrkd6ok2g

https://github.com/bluesky-social/atproto/discussions/5032

>Both of these efforts were a first step toward a new embed type we're calling app.bsky.embed.gallery. This new embed will support up to 10 images, and is intended to be a generic embed that could contain videos in the future.

Seems its now rolling out app/server-wide, and the app crashes whenever my feed tries to display a post with this gallery type.

Tech details:

When BlueskyStatusAdapter deserializes the post (postView.record.bskyJson() at BlueskyStatusAdapter.kt:133, or the quoted-record path at line 157), kotlinx.serialization throws on the unknown subtype.

This happens inside GetFeedsStatusUseCase on Dispatchers.Main.immediate with no try/catch -> the whole app dies, not just that one post.

Solution: Fix GetFeedsStatusUseCase: wrap per-post conversion in try/catch so the undeserializable post is skipped. Stops crashes for gallery and all future unknown types; affected posts just don't render.

Ozone 0.3.3 doesn't support this type.

Long term, lets think about using newer versions of Ozone thru JitPack or maybe forking it off and releasing new tag versions every week out to maven. This issue is due to an Ozone old version.