### PR TITLE
fix: restore star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Manually disable Firebase join compilation
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=0xZhangKe/Fread&type=Date)](https://www.star-history.com/#0xZhangKe/Fread&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=0xZhangKe/Fread&type=Date)](https://star-history.dera.page/#0xZhangKe/Fread&Date)
 
 ## Discussion Group
 - [Telegram](https://t.me/+-SlbKcNbJSphNWI1)


### PR DESCRIPTION
The star history chart is currently broken and no longer renders, which is a shame since it is a great way to show the project's growth. This switches the chart to a working endpoint so it displays correctly again.